### PR TITLE
updates for NZW97 - Hubitat cleanup, logging, child devices, etc.

### DIFF
--- a/Drivers/inovelli-2-channel-outdoor-smart-plug-nzw97.src/inovelli-2-channel-outdoor-smart-plug-nzw97.groovy
+++ b/Drivers/inovelli-2-channel-outdoor-smart-plug-nzw97.src/inovelli-2-channel-outdoor-smart-plug-nzw97.groovy
@@ -32,12 +32,8 @@ metadata {
         importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-2-channel-outdoor-smart-plug-nzw97.src/inovelli-2-channel-outdoor-smart-plug-nzw97.groovy"
     ) {
         capability "Actuator"
-        capability "Sensor"
         capability "Switch"
-        capability "Polling"
         capability "Refresh"
-        capability "Health Check"
-        capability "PushableButton"
         capability "Configuration"
         
         attribute "lastActivity", "String"
@@ -47,52 +43,28 @@ metadata {
                                         [name: "Z-Wave Node*", type:"STRING", description: "Enter the node number (in hex) associated with the node"], 
                                         [name: "Action*", type:"ENUM", constraints: ["Add", "Remove"]],
                                         [name:"Multi-channel Endpoint", type:"NUMBER", description: "Currently not implemented"]] 
-
-        command "childOn"
-        command "childOff"
-        command "childRefresh"
-        command "componentOn"
-        command "componentOff"
-        command "componentRefresh"
-
-        fingerprint manufacturer: "015D", prod: "6100", model: "6100", deviceJoinName: "Inovelli 2-Channel Outdoor Smart Plug"
-        fingerprint manufacturer: "0312", prod: "6100", model: "6100", deviceJoinName: "Inovelli 2-Channel Outdoor Smart Plug"
-        fingerprint manufacturer: "015D", prod: "0221", model: "611C", deviceJoinName: "Inovelli 2-Channel Outdoor Smart Plug"
-        fingerprint manufacturer: "0312", prod: "0221", model: "611C", deviceJoinName: "Inovelli 2-Channel Outdoor Smart Plug"
+                
+        fingerprint mfr: "015D", prod: "6100", deviceId: "6100", deviceJoinName: "Inovelli 2-Channel Outdoor Smart Plug"
+        fingerprint mfr: "0312", prod: "6100", deviceId: "6100", inClusters: "0x5E,0x25,0x85,0x8E,0x59,0x55,0x86,0x72,0x5A,0x73,0x70,0x71,0x9F,0x60,0x6C,0x7A", deviceJoinName: "Inovelli 2-Channel Outdoor Smart Plug"
+        fingerprint mfr: "015D", prod: "0221", deviceId: "611C", deviceJoinName: "Inovelli 2-Channel Outdoor Smart Plug"
+        fingerprint mfr: "0312", prod: "0221", deviceId: "611C", deviceJoinName: "Inovelli 2-Channel Outdoor Smart Plug"
         fingerprint deviceId: "0x1101", inClusters: "0x5E,0x25,0x27,0x85,0x8E,0x59,0x55,0x86,0x72,0x5A,0x73,0x70,0x71,0x60,0x6C,0x7A"
         fingerprint deviceId: "0x1101", inClusters: "0x5E,0x25,0x85,0x8E,0x59,0x55,0x86,0x72,0x5A,0x73,0x70,0x71,0x60,0x6C,0x7A"
     }
     
     simulator {}
     
-    preferences {
-        input "autoOff1", "number", title: "Auto Off Channel 1\n\nAutomatically turn switch off after this number of seconds\nRange: 0 to 32767", description: "Tap to set", required: false, range: "0..32767"
-        input "autoOff2", "number", title: "Auto Off Channel 2\n\nAutomatically turn switch off after this number of seconds\nRange: 0 to 32767", description: "Tap to set", required: false, range: "0..32767"
-        input "ledIndicator", "enum", title: "LED Indicator\n\nTurn LED indicator on when switch is:\n", description: "Tap to set", required: false, options:[["0": "On"], ["1": "Off"], ["2": "Disable"]], defaultValue: "0"
-        input description: "Use the \"Z-Wave Association Tool\" SmartApp to set device associations. (Firmware 1.02+)\n\nGroup 2: Sends on/off commands to associated devices when switch is pressed (BASIC_SET).", title: "Associations", displayDuringSetup: false, type: "paragraph", element: "paragraph"
-    }
+    // TODO:
+    // Association Group 2 - Left outlet
+    // Association Group 3 - Right Outlet
     
-    tiles {
-        multiAttributeTile(name: "switch", type: "lighting", width: 6, height: 4, canChangeIcon: true) {
-            tileAttribute("device.switch", key: "PRIMARY_CONTROL") {
-                attributeState "off", label: '${name}', action: "switch.on", icon: "st.switches.switch.off", backgroundColor: "#ffffff", nextState: "turningOn"
-                attributeState "on", label: '${name}', action: "switch.off", icon: "st.switches.switch.on", backgroundColor: "#00a0dc", nextState: "turningOff"
-                attributeState "turningOff", label: '${name}', action: "switch.on", icon: "st.switches.switch.off", backgroundColor: "#ffffff", nextState: "turningOn"
-                attributeState "turningOn", label: '${name}', action: "switch.off", icon: "st.switches.switch.on", backgroundColor: "#00a0dc", nextState: "turningOff"
-            }
-        }
-        
-        standardTile("refresh", "device.switch", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-            state "default", label: "", action: "refresh.refresh", icon: "st.secondary.refresh"
-        }
-        
-        valueTile("lastActivity", "device.lastActivity", inactiveLabel: false, decoration: "flat", width: 4, height: 1) {
-            state "default", label: 'Last Activity: ${currentValue}',icon: "st.Health & Wellness.health9"
-        }
-        
-        valueTile("icon", "device.icon", inactiveLabel: false, decoration: "flat", width: 4, height: 1) {
-            state "default", label: '', icon: "https://inovelli.com/wp-content/uploads/Device-Handler/Inovelli-Device-Handler-Logo.png"
-        }
+    preferences {
+        input "autoOff1", "number", title: "Auto Off Channel 1", description: "Automatically turn switch off after this number of seconds.\nRange: 0 to 32767", required: false, range: "0..32767"
+        input "autoOff2", "number", title: "Auto Off Channel 2", description: "Automatically turn switch off after this number of seconds.\nRange: 0 to 32767", required: false, range: "0..32767"
+        input "ledIndicator", "enum", title: "LED Indicator", description: "Turn LED indicator on when switch is:", required: false, options:[["0": "On"], ["1": "Off"], ["2": "Disable"]], defaultValue: "0"
+        input description: "Use the \"Z-Wave Association Tool\" SmartApp to set device associations. (Firmware 1.02+)\n\nGroup 2: Sends on/off commands to associated devices when switch is pressed (BASIC_SET).", title: "Associations", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+        input name: "debugEnable", type: "bool", title: "Enable debug logging", defaultValue: false
+        input name: "infoEnable", type: "bool", title: "Enable informational logging", defaultValue: true
     }
 }
 
@@ -106,37 +78,46 @@ private getCommandClassVersions() {
      0x72: 2, // Manufacturer Specific
      0x85: 2, // Association
      0x86: 1, // Version
+        
+     0x5A: 1, // DeviceResetLocally        
+     0x5E: 1, // ZwaveplusInfo  
+     0x7A: 4, // Firmware Update Meta Data
+     0x59: 1, // AssociationGrpInfo   
+     0x9F: 1, // Security 2 
     ]
 }
+
 
 def parse(String description) {
     def result = []
     def cmd = zwave.parse(description, commandClassVersions)
     if (cmd) {
         result += zwaveEvent(cmd)
-        log.debug "Parsed ${cmd} to ${result.inspect()}"
+        logDebug "Parsed ${cmd} to ${result.inspect()}"
     } else {
-        log.debug "Non-parsed event: ${description}"
+        logDebug "Non-parsed event: ${description}"
     }
     
     def now
     if(location.timeZone)
-    now = new Date().format("yyyy MMM dd EEE h:mm:ss a", location.timeZone)
+         now = new Date().format("yyyy MMM dd EEE h:mm:ss a", location.timeZone)
     else
-    now = new Date().format("yyyy MMM dd EEE h:mm:ss a")
+         now = new Date().format("yyyy MMM dd EEE h:mm:ss a")
     sendEvent(name: "lastActivity", value: now, displayed:false)
     
     return result
 }
 
 def zwaveEvent(hubitat.zwave.commands.basicv1.BasicReport cmd, ep = null) {
-    log.debug "BasicReport ${cmd} - ep ${ep}"
+    logDebug "BasicReport ${cmd} - ep ${ep}"
+    def value = cmd.value ? "on" : "off"
     if (ep) {
         def event
         childDevices.each {
             childDevice ->
                 if (childDevice.deviceNetworkId == "$device.deviceNetworkId-ep$ep") {
-                    childDevice.sendEvent(name: "switch", value: cmd.value ? "on" : "off")
+                    // Send the event to the child device for processing/logging
+                    childDevice.parse([[name:"switch", value:value,  descriptionText:"${childDevice.displayName} was turned ${value}"]])
                 }
         }
         if (cmd.value) {
@@ -158,21 +139,30 @@ def zwaveEvent(hubitat.zwave.commands.basicv1.BasicReport cmd, ep = null) {
 }
 
 def zwaveEvent(hubitat.zwave.commands.switchbinaryv1.SwitchBinaryReport cmd, ep = null) {
-    log.debug "SwitchBinaryReport ${cmd} - ep ${ep}"
+    logDebug "SwitchBinaryReport ${cmd} - ep ${ep}"
+    def value = cmd.value ? "on" : "off"
     if (ep) {
         def event
         def childDevice = childDevices.find {
             it.deviceNetworkId == "$device.deviceNetworkId-ep$ep"
         }
-        if (childDevice) childDevice.sendEvent(name: "switch", value: cmd.value ? "on" : "off")
+        if (childDevice) {
+            // Send the event to the child device for processing/logging
+            childDevice.parse([[name:"switch", value:value,  descriptionText:"${childDevice.displayName} was turned ${value}"]])
+        }
+        else
+        {
+            log.error("Unable to find child device $device.deviceNetworkId-ep$ep")
+        }
     } else {
-        def result = createEvent(name: "switch", value: cmd.value ? "on" : "off", type: "digital")
-        return [result] // returns the result of reponse()
+        logInfo("${device.label?device.label:device.name} is ${value}")
+        def result = createEvent(name: "switch", value: value, type: "digital")
+        return [result] // returns the result of createEvent()
     }
 }
 
 def zwaveEvent(hubitat.zwave.commands.multichannelv3.MultiChannelCmdEncap cmd) {
-    log.debug "MultiChannelCmdEncap ${cmd}"
+    logDebug "MultiChannelCmdEncap ${cmd}"
     def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
     if (encapsulatedCommand) {
         zwaveEvent(encapsulatedCommand, cmd.sourceEndPoint as Integer)
@@ -180,92 +170,75 @@ def zwaveEvent(hubitat.zwave.commands.multichannelv3.MultiChannelCmdEncap cmd) {
 }
 
 def zwaveEvent(hubitat.zwave.commands.manufacturerspecificv2.ManufacturerSpecificReport cmd) {
-    log.debug "ManufacturerSpecificReport ${cmd}"
+    logDebug "ManufacturerSpecificReport ${cmd}"
     def msr = String.format("%04X-%04X-%04X", cmd.manufacturerId, cmd.productTypeId, cmd.productId)
-    log.debug "msr: $msr"
+    logDebug "msr: $msr"
     updateDataValue("MSR", msr)
 }
 
 def zwaveEvent(hubitat.zwave.Command cmd) {
     // This will capture any commands not handled by other instances of zwaveEvent
     // and is recommended for development so you can see every command the device sends
-    log.debug "Unhandled Event: ${cmd}"
+    logDebug "Unhandled Event: ${cmd}"
 }
 
 def on() {
-    log.debug "on()"
+    logDebug "on()"
     commands([
-            //zwave.switchAllV1.switchAllOn(),
-            encap(zwave.basicV1.basicSet(value: 0xFF), 1),
-            encap(zwave.basicV1.basicSet(value: 0xFF), 2)
+            // Send a single command to the root device to turn both relays on/off.  This prevents
+            // the device from sending toggling information for each endpoint back as 
+            zwave.switchBinaryV1.switchBinarySet(switchValue: 0xFF)
     ])
 }
 
 def off() {
-    log.debug "off()"
-    commands([
-            //zwave.switchAllV1.switchAllOff(),
-            encap(zwave.basicV1.basicSet(value: 0x00), 1),
-            encap(zwave.basicV1.basicSet(value: 0x00), 2)
+    logDebug "off()"
+    return commands([
+            zwave.switchBinaryV1.switchBinarySet(switchValue: 0x00)
     ])
 }
 
-def childOn(String dni) {
-    log.debug "childOn($dni)"
-    def cmds = []
-    cmds << new hubitat.device.HubAction(command(encap(zwave.basicV1.basicSet(value: 0xFF), channelNumber(dni))), hubitat.device.Protocol.ZWAVE)
-    //cmds << new hubitat.device.HubAction(command(encap(zwave.switchBinaryV1.switchBinaryGet(), channelNumber(dni))), hubitat.device.Protocol.ZWAVE)
-    cmds
-}
-
-def childOff(String dni) {
-    log.debug "childOff($dni)"
-    def cmds = []
-    cmds << new hubitat.device.HubAction(command(encap(zwave.basicV1.basicSet(value: 0x00), channelNumber(dni))), hubitat.device.Protocol.ZWAVE)
-    //cmds << new hubitat.device.HubAction(command(encap(zwave.switchBinaryV1.switchBinaryGet(), channelNumber(dni))), hubitat.device.Protocol.ZWAVE)
-    cmds
-}
-
-def childRefresh(String dni) {
-    log.debug "childRefresh($dni)"
-    def cmds = []
-    cmds << new hubitat.device.HubAction(command(encap(zwave.switchBinaryV1.switchBinaryGet(), channelNumber(dni))), hubitat.device.Protocol.ZWAVE)
-    cmds
-}
-
+// Called from child component devices
 def componentOn(cd) {
-    if (infoEnable) log.info "${device.label?device.label:device.name}: componentOn($cd)"
-    return childOn(cd.deviceNetworkId)
+    logDebug "${device.label?device.label:device.name}: componentOn($cd)"
+    sendHubCommandForChild( zwave.switchBinaryV1.switchBinarySet(switchValue: 0xFF), channelNumber(cd.deviceNetworkId) )
 }
 
 def componentOff(cd) {
-    if (infoEnable) log.info "${device.label?device.label:device.name}: componentOff($cd)"
-    return childOff(cd.deviceNetworkId)
+    logDebug "${device.label?device.label:device.name}: componentOff($cd)"
+    sendHubCommandForChild( zwave.switchBinaryV1.switchBinarySet(switchValue: 0x00), channelNumber(cd.deviceNetworkId) )
 }
 
 def componentRefresh(cd) {
-    if (infoEnable) log.info "${device.label?device.label:device.name}: componentRefresh($cd)"
-    return childRefresh(cd.deviceNetworkId)
+    logDebug "${device.label?device.label:device.name}: componentRefresh($cd)"
+    sendHubCommandForChild( zwave.switchBinaryV1.switchBinaryGet(), channelNumber(cd.deviceNetworkId) )
 }
 
-def poll() {
-    log.debug "poll()"
-    commands([
-            encap(zwave.switchBinaryV1.switchBinaryGet(), 1),
-            encap(zwave.switchBinaryV1.switchBinaryGet(), 2),
-    ])
+def sendHubCommandForChild(cmd, ep) {
+    if (ep && ( ep == 1 || ep == 2 )) {
+        def cmds = []
+        cmds << new hubitat.device.HubAction(command(encap(cmd, ep)), hubitat.device.Protocol.ZWAVE)
+        logDebug("sendHubCommandForChild() sending cmds: ${cmds}")
+        sendHubCommand(cmds)
+    }
+    else
+    {
+        log.error("sendHubCommandForChild() invalid endpoint ${ep}")
+    }
 }
 
 def refresh() {
-    log.debug "refresh()"
+    logDebug "refresh()"
     commands([
+            // Update each relay individually plus the root device
             encap(zwave.switchBinaryV1.switchBinaryGet(), 1),
             encap(zwave.switchBinaryV1.switchBinaryGet(), 2),
+            zwave.switchBinaryV1.switchBinaryGet()
     ])
 }
 
 def ping() {
-    log.debug "ping()"
+    logDebug "ping()"
     refresh()
 }
 
@@ -274,7 +247,7 @@ def installed() {
 }
 
 def configure() {
-    log.debug "configure()"
+    logDebug "configure()"
     def cmds = initialize()
     commands(cmds)
 }
@@ -305,23 +278,23 @@ def integer2Cmd(value, size) {
 	break
 	}
     } catch (e) {
-        log.debug "Error: integer2Cmd $e Value: $value"
+        logDebug "Error: integer2Cmd $e Value: $value"
     }
 }
 
 def updated() {
     if (!state.lastRan || now() >= state.lastRan + 2000) {
-        log.debug "updated()"
+        logDebug "updated()"
         state.lastRan = now()
         def cmds = initialize()
         commands(cmds)
     } else {
-        log.debug "updated() ran within the last 2 seconds. Skipping execution."
+        logDebug "updated() ran within the last 2 seconds. Skipping execution."
     }
 }
 
 def initialize() {
-    log.debug "initialize()"
+    logDebug "initialize()"
     if (!childDevices) {
         createChildDevices()
     } else if (device.label != state.oldLabel) {
@@ -333,8 +306,7 @@ def initialize() {
         }
         state.oldLabel = device.label
     }
-    sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
-    sendEvent(name: "numberOfButtons", value: 1, displayed: true)
+
     def cmds = processAssociations()
     cmds << zwave.configurationV1.configurationSet(scaledConfigurationValue: ledIndicator!=null? ledIndicator.toInteger() : 0, parameterNumber: 1, size: 1)
     cmds << zwave.configurationV1.configurationGet(parameterNumber: 1)
@@ -342,11 +314,16 @@ def initialize() {
     cmds << zwave.configurationV1.configurationGet(parameterNumber: 2)
     cmds << zwave.configurationV1.configurationSet(configurationValue: autoOff2!=null? integer2Cmd(autoOff2.toInteger(), 2) : integer2Cmd(0,2), parameterNumber: 3, size: 2)
     cmds << zwave.configurationV1.configurationGet(parameterNumber: 3)
+    
+    cmds << zwave.versionV1.versionGet()
+    cmds << zwave.firmwareUpdateMdV2.firmwareMdGet()   
+    cmds << zwave.manufacturerSpecificV2.manufacturerSpecificGet()
+
     return cmds
 }
 
 def zwaveEvent(hubitat.zwave.commands.configurationv2.ConfigurationReport cmd) {
-    log.debug "${device.displayName} parameter '${cmd.parameterNumber}' with a byte size of '${cmd.size}' is set to '${cmd.configurationValue}'"
+    logDebug "${device.displayName} parameter '${cmd.parameterNumber}' with a byte size of '${cmd.size}' is set to '${cmd.configurationValue}'"
 }
 
 private encap(cmd, endpoint) {
@@ -411,11 +388,11 @@ def setAssociationGroup(group, nodes, action, endpoint = null){
         node = "${it}"
         switch (action) {
             case "Remove":
-            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            logDebug "Removing node ${node} from association group ${group}"
             associations = associations - node
             break
             case "Add":
-            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            logDebug "Adding node ${node} to association group ${group}"
             associations << node
             break
         }
@@ -426,7 +403,7 @@ def setAssociationGroup(group, nodes, action, endpoint = null){
 
 def maxAssociationGroup(){
    if (!state.associationGroups) {
-       if (logEnable) log.debug "Getting supported association groups from device"
+       if (logEnable) logDebug "Getting supported association groups from device"
        zwave.associationV2.associationGroupingsGet() // execute the update immediately
    }
    (state.associationGroups?: 5) as int
@@ -441,20 +418,20 @@ def processAssociations(){
          if(state."desiredAssociation${i}" != null || state."defaultG${i}") {
             def refreshGroup = false
             ((state."desiredAssociation${i}"? state."desiredAssociation${i}" : [] + state."defaultG${i}") - state."actualAssociation${i}").each {
-                if (logEnable) log.debug "Adding node $it to group $i"
+                logDebug "Adding node $it to group $i"
                 cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
                 refreshGroup = true
             }
             ((state."actualAssociation${i}" - state."defaultG${i}") - state."desiredAssociation${i}").each {
-                if (logEnable) log.debug "Removing node $it from group $i"
+                logDebug "Removing node $it from group $i"
                 cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
                 refreshGroup = true
             }
             if (refreshGroup == true) cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
-            else if (logEnable) log.debug "There are no association actions to complete for group $i"
+            else logDebug "There are no association actions to complete for group $i"
          }
       } else {
-         if (logEnable) log.debug "Association info not known for group $i. Requesting info from device."
+         logDebug "Association info not known for group $i. Requesting info from device."
          cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
       }
    }
@@ -469,22 +446,28 @@ void zwaveEvent(hubitat.zwave.commands.associationv2.AssociationReport cmd) {
        }
     } 
     state."actualAssociation${cmd.groupingIdentifier}" = temp
-    log.debug "Associations for Group ${cmd.groupingIdentifier}: ${temp}"
+    logDebug "Associations for Group ${cmd.groupingIdentifier}: ${temp}"
     updateDataValue("associationGroup${cmd.groupingIdentifier}", "$temp")
 }
 
 def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationGroupingsReport cmd) {
-    log.debug "Supported association groups: ${cmd.supportedGroupings}"
+    logDebug "Supported association groups: ${cmd.supportedGroupings}"
     state.associationGroups = cmd.supportedGroupings
     createEvent(name: "groups", value: cmd.supportedGroupings)
 }
 
 void zwaveEvent(hubitat.zwave.commands.versionv1.VersionReport cmd) {
-    log.debug cmd
+    logDebug cmd
     if(cmd.applicationVersion && cmd.applicationSubVersion) {
 	    def firmware = "${cmd.applicationVersion}.${cmd.applicationSubVersion.toString().padLeft(2,'0')}"
-        state.needfwUpdate = "false"
-        sendEvent(name: "status", value: "fw: ${firmware}")
         updateDataValue("firmware", firmware)
     }
+}
+
+private logDebug(msg) {
+    if (debugEnable) log.debug(msg)
+}
+
+private logInfo(msg) {
+    if (infoEnable) log.info(msg)
 }


### PR DESCRIPTION
Fixes:
- Updated to better use HE Component child devices.  Events are sent to the child parse() routine for info logging and clean dispatching.   Refactored child handling functions.
- Removed unneeded child commands that did not function in the Hubitat UI.
- Fixed issue where on()/off() from the parent was causing the 2nd relay to toggle its reports as it was turning on/off.   

Cleanup:
- Removed unneeded capabilities
- Removed ST tile definitions
- Removed ST "Device Health" concepts, not valid in Hubitat
- Updated fingerprints to Hubitat format
- Added debugging parameters and wrapper functions
- Cleaned up parameter descriptions (was still ST format/style)
- Added MSR / firmware version data on inclusion